### PR TITLE
[BUGFIX] do not reset multipliers on sacrifice when option is deselected

### DIFF
--- a/ts/clickevents.ts
+++ b/ts/clickevents.ts
@@ -198,8 +198,6 @@ const sacrificeToGod = () => {
   if (p.honeyGodTributes > 0) p.hge = true;
   if (p.flowerGodTributes > 0) p.fge = true;
   if (p.capitalistGodTributes > 0) p.cge = true;
-  d.offlineTicksSpeed5.checked = false;
-  d.offlineTicksSpeed10.checked = false;
 
   p.totalSacrifices++;
 };


### PR DESCRIPTION
Do not reset multiplier configuration if desired for multipliers 5x and 10x on sacrifice.